### PR TITLE
Minor pre_attr, fixes htmlmin options

### DIFF
--- a/mkdocs_minify_plugin/plugin.py
+++ b/mkdocs_minify_plugin/plugin.py
@@ -31,7 +31,7 @@ class MinifyPlugin(BasePlugin):
             for key in opts:
                 if key not in ['remove_comments','remove_empty_space','remove_all_empty_space','reduce_boolean_attributes','remove_optional_attribute_quotes','conver_charrefs','keep_pre','pre_tags','pre_attr']:
                     print("htmlmin option " + key + " not recognized")
-            return minify(output_content, opts.get("remove_comments", False), opts.get("remove_empty_space", False), opts.get("remove_all_empty_space", False), opts.get("reduce_empty_attributes", True), opts.get("reduce_boolean_attributes", False), opts.get("remove_optional_attribute_quotes", True), opts.get("convert_charrefs", True), opts.get("keep_pre", False), opts.get("pre_tags", ('pre', 'textarea')), opts.get("pre_tags", 'pre'))
+            return minify(output_content, opts.get("remove_comments", False), opts.get("remove_empty_space", False), opts.get("remove_all_empty_space", False), opts.get("reduce_empty_attributes", True), opts.get("reduce_boolean_attributes", False), opts.get("remove_optional_attribute_quotes", True), opts.get("convert_charrefs", True), opts.get("keep_pre", False), opts.get("pre_tags", ('pre', 'textarea')), opts.get("pre_attr", 'pre'))
         else:
             return output_content
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-minify-plugin',
-    version='0.3.0',
+    version='0.3.1',
     description='An MkDocs plugin to minify HTML and/or JS files prior to being written to disk',
     long_description='',
     keywords='mkdocs minify publishing documentation html css',


### PR DESCRIPTION
"pre_tags" option was doubled for "htmlmin_opts" in a0b2019.

Ref: a0b2019