### PR TITLE
Only the new `cache_safe_extras` option, with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea/
+.vs/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ plugins:
       minify_css: true
       htmlmin_opts:
           remove_comments: true
+      cache_safe_extras: true
       js_files:
           - my/javascript/dir/file1.js
           - my/javascript/dir/file2.js
@@ -40,10 +41,11 @@ plugins:
 - `htmlmin_opts`: Sets runtime htmlmin API options using the [config parameters of htmlmin](https://htmlmin.readthedocs.io/en/latest/reference.html#main-functions)
 - `minify_js`: Sets whether JS files should be minified. Defaults to `false`. If set to `true`, you must specificy the JS to be minified files using `js_files` (see below).
 - `minify_css`: Sets whether CSS files should be minified. Defaults to `false`. If set to `true`, you must specificy the CSS to be minified files using `css_files` (see below).
+- `cache_safe_extras`: Sets whether a hash should be added to the extra JS and CSS file names. Defaults to `false`. If set to `true`, you must specificy the files using `css_files` or `js_files` (see below).
 - `js_files`: List of JS files to be minified. The plugin will generate minified versions of these files and save them as `.min.js` in the output directory.
 - `css_files`: List of CSS files to be minified. The plugin will generate minified versions of these files and save them as `.min.css` in the output directory.
 
-> **Note:** When using `minify_jss` or `minify_css`, you don't have to modify the `extra_javascript` or `extra_css` entries
+> **Note:** When using `minify_js` or `minify_css`, you don't have to modify the `extra_javascript` or `extra_css` entries
 in your `mkdocs.yml` file. The plugins automatically takes care of that.
 
 More information about plugins in the [MkDocs documentation][mkdocs-plugins].

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ plugins:
       minify_css: true
       htmlmin_opts:
           remove_comments: true
-      cache_safe_extras: true
+      cache_safe: true
       js_files:
           - my/javascript/dir/file1.js
           - my/javascript/dir/file2.js
@@ -41,7 +41,7 @@ plugins:
 - `htmlmin_opts`: Sets runtime htmlmin API options using the [config parameters of htmlmin](https://htmlmin.readthedocs.io/en/latest/reference.html#main-functions)
 - `minify_js`: Sets whether JS files should be minified. Defaults to `false`. If set to `true`, you must specificy the JS to be minified files using `js_files` (see below).
 - `minify_css`: Sets whether CSS files should be minified. Defaults to `false`. If set to `true`, you must specificy the CSS to be minified files using `css_files` (see below).
-- `cache_safe_extras`: Sets whether a hash should be added to the extra JS and CSS file names. Defaults to `false`. If set to `true`, you must specificy the files using `css_files` or `js_files` (see below).
+- `cache_safe`: Sets whether a hash should be added to the JS and CSS file names. Defaults to `false`. If set to `true`, you must specificy the files using `css_files` or `js_files` (see below).
 - `js_files`: List of JS files to be minified. The plugin will generate minified versions of these files and save them as `.min.js` in the output directory.
 - `css_files`: List of CSS files to be minified. The plugin will generate minified versions of these files and save them as `.min.css` in the output directory.
 

--- a/mkdocs_minify_plugin/plugin.py
+++ b/mkdocs_minify_plugin/plugin.py
@@ -41,19 +41,19 @@ class MinifyPlugin(BasePlugin):
         ('js_files', mkdocs.config.config_options.Type((str, list), default=None)),
         ('css_files', mkdocs.config.config_options.Type((str, list), default=None)),
         ('htmlmin_opts', mkdocs.config.config_options.Type((str, dict), default=None)),
-        ('cache_safe_extras', mkdocs.config.config_options.Type(bool, default=False)),
+        ('cache_safe', mkdocs.config.config_options.Type(bool, default=False)),
     )
 
     path_to_hash = {}
     """
     The file hash is stored in a dict, so that it's generated only once.
-    Relevant only when `on_pre_build` is run AND `cache_safe_extras` is `True`.
+    Relevant only when `on_pre_build` is run AND `cache_safe` is `True`.
     """
 
     path_to_data = {}
     """
     The file data is stored in a dict, so that it's read only once.
-    Relevant only when `on_pre_build` is run AND `cache_safe_extras` is `True`.
+    Relevant only when `on_pre_build` is run AND `cache_safe` is `True`.
     """
 
     def _minify(self, file_type, config):
@@ -67,7 +67,7 @@ class MinifyPlugin(BasePlugin):
             # Read file and minify
             fn = f"{config['site_dir']}/{file}".replace("\\", "/")
             with open(fn, mode="r+", encoding="utf-8") as f:
-                if self.config["cache_safe_extras"]:
+                if self.config["cache_safe"]:
                     f.write(self.path_to_data[file])
                 else:
                     minified = minify_func(f.read())
@@ -94,9 +94,9 @@ class MinifyPlugin(BasePlugin):
 
                 file_hash = ""
 
-                # When `cache_safe_extras`, the hash is needed before the build,
+                # When `cache_safe`, the hash is needed before the build,
                 # so it's generated from the data from the docs source file
-                if self.config["cache_safe_extras"]:
+                if self.config["cache_safe"]:
                     docs_file_path = f"{config['docs_dir']}/{file}".replace("\\", "/")
 
                     with open(docs_file_path, encoding="utf8") as f:
@@ -133,15 +133,15 @@ class MinifyPlugin(BasePlugin):
             return output_content
 
     def on_pre_build(self, config):
-        if self.config['minify_js'] or self.config["cache_safe_extras"]:
+        if self.config['minify_js'] or self.config["cache_safe"]:
             config = self._minify_extra_config('js', config)
-        if self.config['minify_css'] or self.config["cache_safe_extras"]:
+        if self.config['minify_css'] or self.config["cache_safe"]:
             config = self._minify_extra_config('css', config)
         return config
 
     def on_post_build(self, config):
-        if self.config['minify_js'] or self.config["cache_safe_extras"]:
+        if self.config['minify_js'] or self.config["cache_safe"]:
             self._minify('js', config)
-        if self.config['minify_css'] or self.config["cache_safe_extras"]:
+        if self.config['minify_css'] or self.config["cache_safe"]:
             self._minify('css', config)
         return config

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-minify-plugin',
-    version='0.5.0',
+    version='0.6.0',
     description='An MkDocs plugin to minify HTML, JS or CSS files prior to being written to disk',
     long_description='',
     keywords='mkdocs minify publishing documentation html css',

--- a/tests/fixtures/mkdocs_cache_safe.yml
+++ b/tests/fixtures/mkdocs_cache_safe.yml
@@ -3,7 +3,7 @@ site_name: My Docs
 plugins:
   - search
   - minify:
-      cache_safe_extras: true
+      cache_safe: true
       js_files:
         - extra_assets/js/script.js
       css_files:

--- a/tests/fixtures/mkdocs_cache_safe.yml
+++ b/tests/fixtures/mkdocs_cache_safe.yml
@@ -1,0 +1,16 @@
+site_name: My Docs
+
+plugins:
+  - search
+  - minify:
+      cache_safe_extras: true
+      js_files:
+        - extra_assets/js/script.js
+      css_files:
+        - extra_assets/css/style.css
+
+extra_javascript:
+  - extra_assets/js/script.js
+
+extra_css:
+  - extra_assets/css/style.css

--- a/tests/fixtures/mkdocs_cache_safe_minified.yml
+++ b/tests/fixtures/mkdocs_cache_safe_minified.yml
@@ -1,0 +1,21 @@
+site_name: My Docs
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+      minify_js: true
+      minify_css: true
+      htmlmin_opts:
+        remove_comments: true
+      cache_safe_extras: true
+      js_files:
+        - extra_assets/js/script.js
+      css_files:
+        - extra_assets/css/style.css
+
+extra_javascript:
+  - extra_assets/js/script.js
+
+extra_css:
+  - extra_assets/css/style.css

--- a/tests/fixtures/mkdocs_cache_safe_minified.yml
+++ b/tests/fixtures/mkdocs_cache_safe_minified.yml
@@ -8,7 +8,7 @@ plugins:
       minify_css: true
       htmlmin_opts:
         remove_comments: true
-      cache_safe_extras: true
+      cache_safe: true
       js_files:
         - extra_assets/js/script.js
       css_files:

--- a/tests/fixtures/mkdocs_with_extras.yml
+++ b/tests/fixtures/mkdocs_with_extras.yml
@@ -1,0 +1,20 @@
+site_name: My Docs
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+      minify_js: true
+      minify_css: true
+      htmlmin_opts:
+          remove_comments: true
+      js_files:
+          - extra_assets/js/script.js
+      css_files:
+          - extra_assets/css/style.css
+
+extra_javascript:
+  - extra_assets/js/script.js
+
+extra_css:
+  - extra_assets/css/style.css

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,22 +1,62 @@
+"""
+Pytest test file for the `mkdocs_minify_plugin` module.
+"""
+import hashlib
 from distutils.dir_util import copy_tree
 from pathlib import Path
 from subprocess import check_call
 
 import pytest
 
+# region fixtures
+
 
 @pytest.fixture
 def extra_dir(tmp_path):
+    """Fixture that provides the path to the extra_assets directory after build"""
     return tmp_path / "site" / "extra_assets"
 
 
 @pytest.fixture
 def mkdocs_build(tmp_path):
+    """Fixture that builds mkDocs based on the `mkdocs.yml` file"""
     fixture_dir = str(Path(__file__).parent / "fixtures")
     temp_dir = str(tmp_path)
 
     copy_tree(fixture_dir, temp_dir)
     return check_call(["mkdocs", "build", "-f", f"{temp_dir}/mkdocs.yml"])
+
+
+@pytest.fixture
+def mkdocs_build_with_extras(tmp_path: Path) -> int:
+    """Fixture that builds mkDocs based on the `mkdocs_with_extras.yml` file"""
+    return _build_fixture_base(tmp_path, file_name="mkdocs_with_extras.yml")
+
+
+@pytest.fixture
+def mkdocs_build_cache_safe(tmp_path: Path) -> int:
+    """Fixture that builds mkDocs based on the `mkdocs_cache_safe.yml` file"""
+    return _build_fixture_base(tmp_path, file_name="mkdocs_cache_safe.yml")
+
+
+@pytest.fixture
+def mkdocs_build_cache_safe_minified(tmp_path: Path) -> int:
+    """Fixture that builds mkDocs based on the `mkdocs_cache_safe_minified.yml` file"""
+    return _build_fixture_base(tmp_path, file_name="mkdocs_cache_safe_minified.yml")
+
+
+def _build_fixture_base(tmp_path: Path, *, file_name: str) -> int:
+    """Base function that handles fixture content creation"""
+    fixture_dir: str = str(Path(__file__).parent / "fixtures")
+    temp_dir: str = str(tmp_path)
+
+    copy_tree(fixture_dir, temp_dir)
+    return check_call(["mkdocs", "build", "-f", Path(temp_dir) / file_name])
+
+
+# endregion
+
+# region tests
 
 
 def test_css_is_minified(mkdocs_build, extra_dir):
@@ -31,3 +71,170 @@ def test_js_is_minifed(mkdocs_build, extra_dir):
         minifed = f.read()
 
     assert minifed == r"console.log('Hello World');"
+
+
+def test_build_no_extras(mkdocs_build: int, extra_dir: Path, tmp_path: Path) -> None:
+    """Tests that the extra files are minified but, aren't added to the .html files"""
+    _assert_minified_css(extra_dir / "css" / "style.min.css")
+    _assert_minified_js(extra_dir / "js" / "script.min.js")
+    _assert_minified_template_no_extras(
+        file_path=tmp_path / "site" / "index.html",
+        file_hash="544b92316ee6219418120cfc0347f6f1b996f93833287777345da06a38f5f05e374d87a1a35e6bee96508169262d8f97",
+    )
+    _assert_minified_template_no_extras(
+        file_path=tmp_path / "site" / "404.html",
+        file_hash="91b1fdfb1b0eb78a20992da953b22f4a72b86336bcf7845cd976b5e4a84337b1bdedab7a09f869d9cab80fcb3bd872dc",
+    )
+
+
+def test_build_with_extras(mkdocs_build_with_extras: int, extra_dir: Path, tmp_path: Path) -> None:
+    """Tests that the extra files are minified and are added to the .html files"""
+    _assert_minified_css(extra_dir / "css" / "style.min.css")
+    _assert_minified_js(extra_dir / "js" / "script.min.js")
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "index.html",
+        file_hash="c102275d47fb49aeda0c2e35c35daf5da1ef5ce96f5360cf329578dc65e70b53249b20017b77bcc2516f672917d75762",
+    )
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "404.html",
+        file_hash="e4d3e614fa3a73e6c0b4231d443009a2bfa3fcbd5f548b19b58222d04fcd4c5dadf702904952b7ea3f1cc124d3904c77",
+    )
+
+
+def test_build_cache_safe(mkdocs_build_cache_safe: int, extra_dir: Path, tmp_path: Path) -> None:
+    """Tests that the extra files aren't minified and are added to the .html files with a hashed name."""
+    css_hash_prefix: str = "style.885f1a"
+    js_hash_prefix: str = "script.275b9a"
+
+    with open(extra_dir / "css" / f"{css_hash_prefix}.css", encoding="utf8") as file:
+        css_data: str = file.read()
+
+    assert (
+        hashlib.sha384(css_data.encode("utf8")).hexdigest()
+        == "885f1a3f199708ad6f4d170707080d0066bee0bc4a58d8fee73679c6f6880c52b6885eae5fb6c2b9b337d25b339aaf52"
+    )
+
+    with open(extra_dir / "js" / f"{js_hash_prefix}.js", encoding="utf8") as file:
+        js_data: str = file.read()
+
+    assert (
+        hashlib.sha384(js_data.encode("utf8")).hexdigest()
+        == "275b9a6166c6648a711c4c2b8a2684b99493da5546bc76c8e30d629fbfe5e656a3a72d689758f029f9acb195a9a1702b"
+    )
+
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "index.html",
+        css_prefix=css_hash_prefix,
+        js_prefix=js_hash_prefix,
+        file_hash="315459f1b231791738d6a2be955a469a06a94b9135a776c42cc03250b1b1f3cf9ac0232d9ae34ff7709bf37fa64af558",
+        minified_extras=False,
+        minified_html=False,
+    )
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "404.html",
+        css_prefix=css_hash_prefix,
+        js_prefix=js_hash_prefix,
+        file_hash="10e73a27d3d134aff777399fb8cb2c044d1108f2b91457b7a84026c9afd23e16719eca9f922f977c33f34dcb69017227",
+        minified_extras=False,
+        minified_html=False,
+    )
+
+
+def test_build_cache_safe_minified(
+    mkdocs_build_cache_safe_minified: int, extra_dir: Path, tmp_path: Path
+) -> None:
+    """Tests that the extra files are minified and are added to the .html files with a hashed name."""
+    css_hash_prefix: str = "style.54ca0a"
+    js_hash_prefix: str = "script.fda10b"
+
+    _assert_minified_css(extra_dir / "css" / f"{css_hash_prefix}.min.css")
+    _assert_minified_js(extra_dir / "js" / f"{js_hash_prefix}.min.js")
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "index.html",
+        css_prefix=css_hash_prefix,
+        js_prefix=js_hash_prefix,
+        file_hash="4e4abcfcf21f0220799141c9aa67500ff95ade5725351f7f2980a3484dc285c222864b6065bb6ed8d91343e7c0398357",
+    )
+    _assert_template_with_extras(
+        file_path=tmp_path / "site" / "404.html",
+        css_prefix=css_hash_prefix,
+        js_prefix=js_hash_prefix,
+        file_hash="ba1971d561cbd38ece2bb7f45aff9fadf7fe7b766bcd71341af3b99b7109c5c3dc9930c37ea69f05f3c841fc698147b6",
+    )
+
+
+# endregion
+
+# region assertion helpers
+
+
+def _assert_minified_css(file_path: Path) -> None:
+    """Asserts the contents of the minified css file and compares the checksum hash"""
+    with open(file_path, encoding="utf8") as file:
+        minified: str = file.read()
+
+    assert minified == r".ui-hidden{display:none}"
+    assert (
+        hashlib.sha384(minified.encode("utf8")).hexdigest()
+        == "54ca0a60263b2bf48ec6c74bb27ff3bdd000442f73e0b78811a5c097ac1d2b0e7b8fea17fe16f9d9618b76566a3ea171"
+    )
+
+
+def _assert_minified_js(file_path: Path) -> None:
+    """Asserts the contents of the minified js file and compares the checksum hash"""
+    with open(file_path, encoding="utf8") as file:
+        minified: str = file.read()
+
+    assert minified == r"console.log('Hello World');"
+    assert (
+        hashlib.sha384(minified.encode("utf8")).hexdigest()
+        == "fda10b7f2831f8b6121a9f65c809876b4aa52b2fee3a1084a6d101e12e042abf6ff7cf028d557b101e18ff156877b981"
+    )
+
+
+def _assert_minified_template_no_extras(
+    *, file_path: Path, css_prefix: str = "style", js_prefix: str = "script", file_hash: str
+) -> None:
+    """Asserts that the extra files aren't added to the .html files and compares the checksum hash"""
+    with open(file_path, encoding="utf8") as file:
+        minified: str = file.read()
+
+    assert f"extra_assets/js/{js_prefix}.js" not in minified
+    assert f"extra_assets/css/{css_prefix}.css" not in minified
+    assert f"extra_assets/js/{js_prefix}.min.js" not in minified
+    assert f"extra_assets/css/{css_prefix}.min.css" not in minified
+    assert hashlib.sha384(minified.encode("utf8")).hexdigest() == file_hash
+
+
+def _assert_template_with_extras(
+    *,
+    file_path: Path,
+    css_prefix: str = "style",
+    js_prefix: str = "script",
+    file_hash: str,
+    minified_extras: bool = True,
+    minified_html: bool = True,
+) -> None:
+    """Asserts that the extra files are added to the .html files and compares the checksum hash"""
+    with open(file_path, encoding="utf8") as file:
+        file_data: str = file.read()
+
+    if not minified_html:
+        # remove timestamp comment for constant hash
+        file_data = "\n".join(file_data.splitlines()[:-6])
+
+    if minified_extras:
+        assert f"extra_assets/js/{js_prefix}.js" not in file_data
+        assert f"extra_assets/css/{css_prefix}.css" not in file_data
+        assert f"extra_assets/js/{js_prefix}.min.js" in file_data
+        assert f"extra_assets/css/{css_prefix}.min.css" in file_data
+    else:
+        assert f"extra_assets/js/{js_prefix}.js" in file_data
+        assert f"extra_assets/css/{css_prefix}.css" in file_data
+        assert f"extra_assets/js/{js_prefix}.min.js" not in file_data
+        assert f"extra_assets/css/{css_prefix}.min.css" not in file_data
+
+    assert hashlib.sha384(file_data.encode("utf8")).hexdigest() == file_hash
+
+
+# endregion


### PR DESCRIPTION
Hi, 👋 
as discussed in #19, I'm splitting the PR into multiple ones.  

This PR adds the new option and a version bump. I preserved the structure and most of the code from the previous branch HEAD, so it's easier to see what was added and where for this option alone. 
Apart from the option, tests were added to make sure that the old code works the same way and the new code works properly. I might remove the old tests in the future, as they are redundant currently, but kept them for now to limit the amount of removals in this PR.

I'll make more changes in another PR later.