### PR TITLE
CI: test against all supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,20 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "requirements.txt"
+
       - name: Install dependencies
         run: |
-          pip install -r tests/requirements.txt
-          pip install -e .
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade -r requirements.txt
+          python -m pip install pip install -e .
+          
       - name: Run tests
         run: pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade -r requirements.txt
+          python -m pip install --upgrade -r tests/requirements.txt
           python -m pip install pip install -e .
           
       - name: Run tests


### PR DESCRIPTION
Hello,

First of all, thanks for your great plugin. I'm using it on a big docs base and it works like a charm.

I'm the maintainer of the RSS plugin and using minify-plugin for the plugin documentation. So your plugin is not a critical dependency of my plugin but [I've been warned by dependabot](https://github.com/Guts/mkdocs-rss-plugin/pull/153) that upgrading your plugin to 0.6.* breaks my test and build.

I've checked and your plugin is supporting Python 3.7.

So in this PR, I propose to test the plugin against every Python supported versions (from [setup.py](https://github.com/byrnereese/mkdocs-minify-plugin/blob/master/setup.py#L27-L30))