### PR TITLE
chore: add python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-    
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
     steps:
       - uses: actions/checkout@v3
 
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade -r tests/requirements.txt
-          python -m pip install pip install -e .
-          
+          python -m pip install -e .
+
       - name: Run tests
         run: pytest -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mkdocs-minify-plugin
 
+[![PyPI - Python Version][python-image]][pypi-link]
+
 An MkDocs plugin to minify HTML, JS or CSS files prior to being written to disk.
 
 HTML minification is done using [htmlmin](https://github.com/mankyd/htmlmin).
@@ -12,7 +14,9 @@ CSS minification is done using [csscompressor](https://github.com/sprymix/csscom
 
 Install the plugin using pip:
 
-`pip install mkdocs-minify-plugin`
+```bash
+pip install mkdocs-minify-plugin
+```
 
 Activate the plugin in `mkdocs.yml`:
 
@@ -67,3 +71,6 @@ plugins:
 
 > **Note:** When using `minify_js` or `minify_css`, you don't have to modify the `extra_javascript` or `extra_css` entries
 in your `mkdocs.yml` file. The plugins automatically takes care of that.
+
+[pypi-link]: https://pypi.python.org/pypi/mkdocs-minify-plugin/
+[python-image]: https://img.shields.io/pypi/pyversions/mkdocs-minify-plugin?logo=python&logoColor=aaaaaa&labelColor=333333

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
Extension of #24 to Python 3.11.

Also, I've added a badge to the front page so that it's clear to everyone what python versions are supported by the library.

![image](https://user-images.githubusercontent.com/30731072/213905983-c7922e16-92ef-42d6-85b8-150c3c1c5b23.png)

(it should show 3.11 after we push to pypi)