### PR TITLE
Maintenance for MkDocs 1.5.0

### DIFF
--- a/mkdocs_minify_plugin/plugin.py
+++ b/mkdocs_minify_plugin/plugin.py
@@ -158,14 +158,21 @@ class MinifyPlugin(BasePlugin):
             # A valid path in a custom_dir takes priority.
             if self.config["cache_safe"]:
                 docs_file_path: str = f"{config['docs_dir']}/{file_path}".replace("\\", "/")
+                theme = config.theme
 
-                for user_config in config.user_configs:
-                    user_config: Dict
-                    custom_dir: str = user_config.get("theme", {}).get("custom_dir", "")
-                    temp_path: str = f"{custom_dir}/{file_path}".replace("\\", "/")
-                    if custom_dir and os.path.exists(temp_path):
+                # Since MkDocs 1.5.0, theme.custom_dir is available for direct access
+                if not hasattr(theme, "custom_dir"):
+                    for user_config in config.user_configs:
+                        user_config: Dict
+                        custom_dir: str = user_config.get("theme", {}).get("custom_dir", "")
+                        temp_path: str = f"{custom_dir}/{file_path}".replace("\\", "/")
+                        if custom_dir and os.path.exists(temp_path):
+                            docs_file_path = temp_path
+                            break
+                elif theme.custom_dir:
+                    temp_path: str = f"{theme.custom_dir}/{file_path}".replace("\\", "/")
+                    if os.path.exists(temp_path):
                         docs_file_path = temp_path
-                        break
 
                 with open(docs_file_path, encoding="utf8") as file:
                     file_data: str = file.read()


### PR DESCRIPTION
Hi 👋,
MkDocs 1.5.0 adds the `theme.custom_dir` property for ease of access and deprecates the previous `theme._vars` and `config.user_configs`. I updated the script to handle both cases via a simple API check, the assumption currently is that the `theme.custom_dir` won't be going away so I felt this is a cleaner approach that comparing the `mkdocs.__version__`.

Also tests will need to be adjusted, since they now rely on the source not changing... the themes change 1.5.0, which in turn will break every test case, because they rely on hashes... 😑I now see that hashes weren't such a good idea, I will try to handle it somehow in the coming days, since I take partial blame in the test design. 

If this PR won't be merged before 1.5.0 then the world won't end, people will just have to live with the Deprecation warning for some time.