### PR TITLE
Workaround pathlib glob not supporting dir symlinks, use tdewolff-minify instead of htmlmin2

### DIFF
--- a/mkdocs_minify_plugin/plugin.py
+++ b/mkdocs_minify_plugin/plugin.py
@@ -5,6 +5,7 @@ import hashlib
 from pathlib import Path
 import os
 from typing import Callable, Dict, List, Optional, Tuple, Union
+from glob import glob
 
 import csscompressor
 import htmlmin
@@ -90,7 +91,10 @@ class MinifyPlugin(BasePlugin):
             if "*" in file_path:
                 glob_parts = file_path.split("*", maxsplit=1)
                 glob_dir = site_dir / Path(glob_parts[0])
-                file_path = glob_dir.glob(f"*{glob_parts[1]}")
+                file_path = [
+                    Path(file)
+                    for file in glob(str(f"{glob_dir}/*{glob_parts[1]}"), recursive=True)
+                ]
 
                 for glob_file in file_path:
                     file_paths2.append(glob_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs>=1.4.1
-htmlmin2>=0.1.13
+tdewolff-minify==2.20.16
 jsmin>=3.0.1
 csscompressor>=0.9.5

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "mkdocs>=1.4.1",
-        "htmlmin2>=0.1.13",
+        "tdewolff-minify>=2.20.16",
         "jsmin>=3.0.1",
         "csscompressor>=0.9.5",
     ],


### PR DESCRIPTION
1. [ ] [Pathlib glob does not include files from directories that are symlinked for Python <3.13](https://github.com/python/cpython/issues/77609), work-around is to just use `glob.glob` instead with the `recursive=True` flag set
2. [ ] Migrate to use tdewolff-minify instead of htmlmin2
    - Closes #32 
    - not only does it look like the performance is better but seems like that project is actively supported